### PR TITLE
Fix navigation sort

### DIFF
--- a/merge_branches.sh
+++ b/merge_branches.sh
@@ -2,12 +2,13 @@
 
 set -x
 
-git remote add upstream https://github.com/plone/plone.restapi.git
+#git remote add upstream https://github.com/plone/plone.restapi.git
 
 git fetch --all
 git pull
-git merge origin/improve_portlets_v2
-git merge upstream/master
+git merge origin/fix_navigation_sort
+#git merge origin/improve_portlets_v2
+#git merge upstream/master
 
 # Merged
 # git merge --no-ff upstream/eea-dx-cpanel-metadata

--- a/src/plone/restapi/services/navigation/get.py
+++ b/src/plone/restapi/services/navigation/get.py
@@ -97,9 +97,9 @@ class Navigation(object):
     @property
     def current_language(self):
         return (
-            self.request.get("LANGUAGE", None)
-            or (self.context and aq_inner(self.context).Language())
-            or self.default_language
+            self.request.get("LANGUAGE", None) or
+            (self.context and aq_inner(self.context).Language()) or
+            self.default_language
         )
 
     @property
@@ -140,6 +140,7 @@ class Navigation(object):
             "portal_type": {"query": self.settings["displayed_types"]},
             "Language": self.current_language,
             "is_default_page": False,
+            "sort_on": "getObjPositionInParent",
         }
 
         if not self.settings["nonfolderish_tabs"]:


### PR DESCRIPTION
Navigation endpoint sort by object position in parent
(https://github.com/plone/plone.restapi/issues/1107)
NO LONGER WORKS IN plone.restapi 8.0.0